### PR TITLE
Introduce MinThickness for Strikeout and Underline

### DIFF
--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -669,6 +669,8 @@ namespace Topten.RichTextKit
                             if (underlineYPos < Line.YCoord + Line.BaseLine + 1)
                                 underlineYPos = Line.YCoord + Line.BaseLine + 1;
                             paint.StrokeWidth = _font.Metrics.UnderlineThickness ?? 1;
+                            if (ctx.Canvas.TotalMatrix.ScaleY * paint.StrokeWidth < Style.MinThickness)
+                                paint.StrokeWidth = Style.MinThickness;
                             paintHalo.StrokeWidth = paint.StrokeWidth + Style.HaloWidth;
 
                             if (Style.Underline == UnderlineStyle.Gapped)
@@ -733,6 +735,8 @@ namespace Topten.RichTextKit
                             if (Style.StrikeThrough != StrikeThroughStyle.None && RunKind == FontRunKind.Normal)
                             {
                                 paintHalo.StrokeWidth = _font.Metrics.StrikeoutThickness ?? 1;
+                                if (ctx.Canvas.TotalMatrix.ScaleY * paintHalo.StrokeWidth < Style.MinThickness)
+                                    paintHalo.StrokeWidth = Style.MinThickness;
                                 paintHalo.StrokeWidth += Style.HaloWidth;
                                 float strikeYPos = Line.YCoord + Line.BaseLine + (_font.Metrics.StrikeoutPosition ?? 0) + glyphVOffset;
                                 ctx.Canvas.DrawLine(new SKPoint(XCoord, strikeYPos), new SKPoint(XCoord + Width, strikeYPos), paintHalo);
@@ -748,6 +752,8 @@ namespace Topten.RichTextKit
                 if (Style.StrikeThrough != StrikeThroughStyle.None && RunKind == FontRunKind.Normal)
                 {
                     paint.StrokeWidth = _font.Metrics.StrikeoutThickness ?? 1;
+                    if (ctx.Canvas.TotalMatrix.ScaleY * paint.StrokeWidth < Style.MinThickness)
+                        paint.StrokeWidth = Style.MinThickness;
                     float strikeYPos = Line.YCoord + Line.BaseLine + (_font.Metrics.StrikeoutPosition ?? 0) + glyphVOffset;
                     ctx.Canvas.DrawLine(new SKPoint(XCoord, strikeYPos), new SKPoint(XCoord + Width, strikeYPos), paint);
                 }

--- a/Topten.RichTextKit/IStyle.cs
+++ b/Topten.RichTextKit/IStyle.cs
@@ -112,5 +112,10 @@ namespace Topten.RichTextKit
         /// Specifies a replacement character to be displayed (password mode)
         /// </summary>
         char ReplacementCharacter { get; }
+
+        /// <summary>
+        /// Specifies the min thickness of strikeout and underline
+        /// </summary>
+        float MinThickness {get; }
     }
 }

--- a/Topten.RichTextKit/Style.cs
+++ b/Topten.RichTextKit/Style.cs
@@ -208,6 +208,12 @@ namespace Topten.RichTextKit
             set { CheckNotSealed(); _replacementCharacter = value; }
         }
 
+        public float MinThickness
+        {
+            get => _minThickness;
+            set { CheckNotSealed(); _minThickness = value; }
+        }
+
 
         bool _sealed;
         string _fontFamily = "Arial";
@@ -227,6 +233,7 @@ namespace Topten.RichTextKit
         FontVariant _fontVariant;
         TextDirection _textDirection = TextDirection.Auto;
         char _replacementCharacter = '\0';
+        float _minThickness = 1f;
 
         /// <summary>
         /// Modifies this style with one or more attribute changes and returns a new style
@@ -271,7 +278,8 @@ namespace Topten.RichTextKit
                float? letterSpacing = null,
                FontVariant? fontVariant = null,
                TextDirection? textDirection = null,
-               char? replacementCharacter = null
+               char? replacementCharacter = null,
+               float? minThickness = 1f
             )
         {
             // Resolve new style against current style
@@ -294,6 +302,7 @@ namespace Topten.RichTextKit
                 FontVariant = fontVariant ?? this.FontVariant,
                 TextDirection = textDirection ?? this.TextDirection,
                 ReplacementCharacter = replacementCharacter ?? this.ReplacementCharacter,
+                MinThickness = minThickness ?? this.MinThickness
             };
         }
     }


### PR DESCRIPTION
Introduce the property MinThickness for IStyle to render the strikeout and underline correctly.